### PR TITLE
Various minor tidy ups

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,6 @@
 # The service providing the commit statuses to GitHub.
-status = [
-    "buildbot/buildbot-build-script"
-]
+
+status = ["buildbot/yk-buildbot-build-script-hw"]
 
 # Allow 10 minutes for builds.
 timeout_sec = 600

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-use cc;
 use core::arch::x86_64::__cpuid_count;
 use rerun_except::rerun_except;
 use std::env;

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -1,6 +1,6 @@
 use super::PerfPTConfig;
 use crate::errors::HWTracerError;
-use crate::{Block, ThreadTracer, Trace, Tracer, TracerState};
+use crate::{Block, ThreadTracer, Trace, Tracer};
 use libc::{c_char, c_int, c_void, free, geteuid, malloc, size_t};
 use std::error::Error;
 use std::ffi::{self, CStr, CString};
@@ -373,7 +373,7 @@ pub struct PerfPTThreadTracer {
     // Opaque C pointer representing the tracer context.
     tracer_ctx: *mut c_void,
     // The state of the tracer.
-    state: TracerState,
+    is_tracing: bool,
     // The trace currently being collected, or `None`.
     trace: Option<Box<PerfPTTrace>>,
 }
@@ -383,7 +383,7 @@ impl PerfPTThreadTracer {
         Self {
             config,
             tracer_ctx: ptr::null_mut(),
-            state: TracerState::Stopped,
+            is_tracing: false,
             trace: None,
         }
     }
@@ -397,7 +397,7 @@ impl Default for PerfPTThreadTracer {
 
 impl Drop for PerfPTThreadTracer {
     fn drop(&mut self) {
-        if self.state == TracerState::Started {
+        if self.is_tracing {
             // If we haven't stopped the tracer already, stop it now.
             self.stop_tracing().unwrap();
         }
@@ -406,8 +406,8 @@ impl Drop for PerfPTThreadTracer {
 
 impl ThreadTracer for PerfPTThreadTracer {
     fn start_tracing(&mut self) -> Result<(), HWTracerError> {
-        if self.state == TracerState::Started {
-            return Err(TracerState::Started.as_error());
+        if self.is_tracing {
+            return Err(HWTracerError::AlreadyTracing);
         }
 
         // At the time of writing, we have to use a fresh Perf file descriptor to ensure traces
@@ -430,18 +430,18 @@ impl ThreadTracer for PerfPTThreadTracer {
         if !unsafe { perf_pt_start_tracer(self.tracer_ctx, &mut *trace, &mut cerr) } {
             return Err(cerr.into());
         }
-        self.state = TracerState::Started;
+        self.is_tracing = true;
         self.trace = Some(trace);
         Ok(())
     }
 
     fn stop_tracing(&mut self) -> Result<Box<dyn Trace>, HWTracerError> {
-        if self.state == TracerState::Stopped {
-            return Err(TracerState::Stopped.as_error());
+        if !self.is_tracing {
+            return Err(HWTracerError::AlreadyStopped);
         }
         let mut cerr = PerfPTCError::new();
         let rc = unsafe { perf_pt_stop_tracer(self.tracer_ctx, &mut cerr) };
-        self.state = TracerState::Stopped;
+        self.is_tracing = false;
         if !rc {
             return Err(cerr.into());
         }

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -42,7 +42,7 @@ impl Error for LibIPTError {
 
 #[repr(C)]
 #[allow(dead_code)] // Only C constructs these.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 enum PerfPTCErrorKind {
     Unused,
     Unknown,

--- a/src/block.rs
+++ b/src/block.rs
@@ -4,14 +4,16 @@ type BlockAddr = u64;
 /// Information about a basic block.
 #[derive(Debug, Eq, PartialEq)]
 pub struct Block {
-    /// Virtual address of the first instruction in this block.
+    /// Virtual address of the start of the first instruction in this block.
     first_instr: BlockAddr,
-    /// Virtual address of the last instruction in this block.
+    /// Virtual address of the start of the last instruction in this block.
     last_instr: BlockAddr,
 }
 
 impl Block {
-    /// Creates a new basic block from a start address and a length in bytes.
+    /// Creates a new basic block from the virtual addresses of:
+    ///   * the start of the first instruction in the basic block.
+    ///   * the start of the last instruction in the basic block.
     pub fn new(first_instr: BlockAddr, last_instr: BlockAddr) -> Self {
         Self {
             first_instr,
@@ -19,12 +21,12 @@ impl Block {
         }
     }
 
-    /// Returns the virtual address of the first instruction in this block.
+    /// Returns the virtual address of the start of the first instruction in this block.
     pub fn first_instr(&self) -> BlockAddr {
         self.first_instr
     }
 
-    /// Returns the virtual address of the last instruction in this block.
+    /// Returns the virtual address of the start of the last instruction in this block.
     pub fn last_instr(&self) -> BlockAddr {
         self.last_instr
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,0 +1,28 @@
+/// Information about a basic block.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Block {
+    /// Virtual address of the first instruction in this block.
+    first_instr: u64,
+    /// Virtual address of the last instruction in this block.
+    last_instr: u64,
+}
+
+impl Block {
+    /// Creates a new basic block from a start address and a length in bytes.
+    pub fn new(first_instr: u64, last_instr: u64) -> Self {
+        Self {
+            first_instr,
+            last_instr,
+        }
+    }
+
+    /// Returns the virtual address of the first instruction in this block.
+    pub fn first_instr(&self) -> u64 {
+        self.first_instr
+    }
+
+    /// Returns the virtual address of the last instruction in this block.
+    pub fn last_instr(&self) -> u64 {
+        self.last_instr
+    }
+}

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,15 +1,18 @@
+#[cfg(target_arch = "x86_64")]
+type BlockAddr = u64;
+
 /// Information about a basic block.
 #[derive(Debug, Eq, PartialEq)]
 pub struct Block {
     /// Virtual address of the first instruction in this block.
-    first_instr: u64,
+    first_instr: BlockAddr,
     /// Virtual address of the last instruction in this block.
-    last_instr: u64,
+    last_instr: BlockAddr,
 }
 
 impl Block {
     /// Creates a new basic block from a start address and a length in bytes.
-    pub fn new(first_instr: u64, last_instr: u64) -> Self {
+    pub fn new(first_instr: BlockAddr, last_instr: BlockAddr) -> Self {
         Self {
             first_instr,
             last_instr,
@@ -17,12 +20,12 @@ impl Block {
     }
 
     /// Returns the virtual address of the first instruction in this block.
-    pub fn first_instr(&self) -> u64 {
+    pub fn first_instr(&self) -> BlockAddr {
         self.first_instr
     }
 
     /// Returns the virtual address of the last instruction in this block.
-    pub fn last_instr(&self) -> u64 {
+    pub fn last_instr(&self) -> BlockAddr {
         self.last_instr
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,6 @@ use std::iter::Iterator;
 ///
 /// Each backend has its own concrete implementation.
 pub trait Trace: Debug + Send {
-    /// Dump the trace to the specified filename.
-    ///
-    /// The exact format varies per-backend.
-    #[cfg(test)]
-    fn to_file(&self, file: &mut File);
-
     /// Iterate over the blocks of the trace.
     fn iter_blocks<'t: 'i, 'i>(
         &'t self,
@@ -32,6 +26,12 @@ pub trait Trace: Debug + Send {
     /// Get the capacity of the trace in bytes.
     #[cfg(test)]
     fn capacity(&self) -> usize;
+
+    /// Dump the trace to the specified filename.
+    ///
+    /// The exact format varies per-backend.
+    #[cfg(test)]
+    fn to_file(&self, file: &mut File);
 }
 
 /// The interface offered by all tracer types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
+mod block;
+pub use block::Block;
 pub mod backends;
 pub mod errors;
 
@@ -10,35 +12,6 @@ use std::fmt::{self, Display, Formatter};
 #[cfg(test)]
 use std::fs::File;
 use std::iter::Iterator;
-
-/// Information about a basic block.
-#[derive(Debug, Eq, PartialEq)]
-pub struct Block {
-    /// Virtual address of the first instruction in this block.
-    first_instr: u64,
-    /// Virtual address of the last instruction in this block.
-    last_instr: u64,
-}
-
-impl Block {
-    /// Creates a new basic block from a start address and a length in bytes.
-    pub fn new(first_instr: u64, last_instr: u64) -> Self {
-        Self {
-            first_instr,
-            last_instr,
-        }
-    }
-
-    /// Returns the virtual address of the first instruction in this block.
-    pub fn first_instr(&self) -> u64 {
-        self.first_instr
-    }
-
-    /// Returns the virtual address of the last instruction in this block.
-    pub fn last_instr(&self) -> u64 {
-        self.last_instr
-    }
-}
 
 /// Represents a generic trace.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::new_without_default)]
 
 mod block;
 pub use block::Block;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ mod test_helpers;
 
 pub use errors::HWTracerError;
 use std::fmt::Debug;
-use std::fmt::{self, Display, Formatter};
 #[cfg(test)]
 use std::fs::File;
 use std::iter::Iterator;
@@ -50,27 +49,4 @@ pub trait ThreadTracer {
     ///
     /// [start_tracing](trait.ThreadTracer.html#method.start_tracing) must have been called prior.
     fn stop_tracing(&mut self) -> Result<Box<dyn Trace>, HWTracerError>;
-}
-
-// Keeps track of the internal state of a tracer.
-#[derive(PartialEq, Eq, Debug)]
-pub enum TracerState {
-    Stopped,
-    Started,
-}
-
-impl TracerState {
-    /// Returns the error corresponding with the `TracerState`.
-    pub fn as_error(self) -> HWTracerError {
-        HWTracerError::TracerState(self)
-    }
-}
-
-impl Display for TracerState {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match *self {
-            TracerState::Started => write!(f, "started"),
-            TracerState::Stopped => write!(f, "stopped"),
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ mod block;
 pub use block::Block;
 pub mod backends;
 pub mod errors;
+#[cfg(test)]
+mod test_helpers;
 
 pub use errors::HWTracerError;
 use std::fmt::Debug;
@@ -70,117 +72,5 @@ impl Display for TracerState {
             TracerState::Started => write!(f, "started"),
             TracerState::Stopped => write!(f, "stopped"),
         }
-    }
-}
-
-// Test helpers.
-//
-// Each struct implementing the [ThreadTracer](trait.ThreadTracer.html) trait should include tests
-// calling the following helpers.
-#[cfg(test)]
-mod test_helpers {
-    use super::{Block, HWTracerError, ThreadTracer, TracerState};
-    use crate::Trace;
-    use std::slice::Iter;
-    use std::time::SystemTime;
-
-    // A loop that does some work that we can use to build a trace.
-    #[inline(never)]
-    pub fn work_loop(iters: u64) -> u64 {
-        let mut res = 0;
-        for _ in 0..iters {
-            // Computation which stops the compiler from eliminating the loop.
-            res += SystemTime::now().elapsed().unwrap().subsec_nanos() as u64;
-        }
-        res
-    }
-
-    // Trace a closure that returns a u64.
-    pub fn trace_closure<F>(tracer: &mut dyn ThreadTracer, f: F) -> Box<dyn Trace>
-    where
-        F: FnOnce() -> u64,
-    {
-        tracer.start_tracing().unwrap();
-        let res = f();
-        let trace = tracer.stop_tracing().unwrap();
-        println!("traced closure with result: {}", res); // To avoid over-optimisation.
-        trace
-    }
-
-    // Check that starting and stopping a tracer works.
-    pub fn test_basic_usage<T>(mut tracer: T)
-    where
-        T: ThreadTracer,
-    {
-        trace_closure(&mut tracer, || work_loop(500));
-    }
-
-    // Check that repeated usage of the same tracer works.
-    pub fn test_repeated_tracing<T>(mut tracer: T)
-    where
-        T: ThreadTracer,
-    {
-        for _ in 0..10 {
-            trace_closure(&mut tracer, || work_loop(500));
-        }
-    }
-
-    // Check that starting a tracer twice makes an appropriate error.
-    pub fn test_already_started<T>(mut tracer: T)
-    where
-        T: ThreadTracer,
-    {
-        tracer.start_tracing().unwrap();
-        match tracer.start_tracing() {
-            Err(HWTracerError::TracerState(TracerState::Started)) => (),
-            _ => panic!(),
-        };
-        tracer.stop_tracing().unwrap();
-    }
-
-    // Check that stopping an unstarted tracer makes an appropriate error.
-    pub fn test_not_started<T>(mut tracer: T)
-    where
-        T: ThreadTracer,
-    {
-        match tracer.stop_tracing() {
-            Err(HWTracerError::TracerState(TracerState::Stopped)) => (),
-            _ => panic!(),
-        };
-    }
-
-    // Helper to check an expected list of blocks matches what we actually got.
-    pub fn test_expected_blocks(trace: Box<dyn Trace>, mut expect_iter: Iter<Block>) {
-        let mut got_iter = trace.iter_blocks();
-        loop {
-            let expect = expect_iter.next();
-            let got = got_iter.next();
-            if expect.is_none() || got.is_none() {
-                break;
-            }
-            assert_eq!(
-                got.unwrap().unwrap().first_instr(),
-                expect.unwrap().first_instr()
-            );
-        }
-        // Check that both iterators were the same length.
-        assert!(expect_iter.next().is_none());
-        assert!(got_iter.next().is_none());
-    }
-
-    // Trace two loops, one 10x larger than the other, then check the proportions match the number
-    // of block the trace passes through.
-    #[cfg(perf_pt_test)]
-    pub fn test_ten_times_as_many_blocks<T>(mut tracer1: T, mut tracer2: T)
-    where
-        T: ThreadTracer,
-    {
-        let trace1 = trace_closure(&mut tracer1, || work_loop(10));
-        let trace2 = trace_closure(&mut tracer2, || work_loop(100));
-
-        // Should be roughly 10x more blocks in trace2. It won't be exactly 10x, due to the stuff
-        // we trace either side of the loop itself. On a smallish trace, that will be significant.
-        let (ct1, ct2) = (trace1.iter_blocks().count(), trace2.iter_blocks().count());
-        assert!(ct2 > ct1 * 9);
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,111 @@
+//! Test helpers.
+//!
+//! Each struct implementing the [ThreadTracer](trait.ThreadTracer.html) trait should include tests
+//! calling the following helpers.
+
+#![cfg(test)]
+
+use super::{Block, HWTracerError, ThreadTracer, TracerState};
+use crate::Trace;
+use std::slice::Iter;
+use std::time::SystemTime;
+
+// A loop that does some work that we can use to build a trace.
+#[inline(never)]
+pub fn work_loop(iters: u64) -> u64 {
+    let mut res = 0;
+    for _ in 0..iters {
+        // Computation which stops the compiler from eliminating the loop.
+        res += SystemTime::now().elapsed().unwrap().subsec_nanos() as u64;
+    }
+    res
+}
+
+// Trace a closure that returns a u64.
+pub fn trace_closure<F>(tracer: &mut dyn ThreadTracer, f: F) -> Box<dyn Trace>
+where
+    F: FnOnce() -> u64,
+{
+    tracer.start_tracing().unwrap();
+    let res = f();
+    let trace = tracer.stop_tracing().unwrap();
+    println!("traced closure with result: {}", res); // To avoid over-optimisation.
+    trace
+}
+
+// Check that starting and stopping a tracer works.
+pub fn test_basic_usage<T>(mut tracer: T)
+where
+    T: ThreadTracer,
+{
+    trace_closure(&mut tracer, || work_loop(500));
+}
+
+// Check that repeated usage of the same tracer works.
+pub fn test_repeated_tracing<T>(mut tracer: T)
+where
+    T: ThreadTracer,
+{
+    for _ in 0..10 {
+        trace_closure(&mut tracer, || work_loop(500));
+    }
+}
+
+// Check that starting a tracer twice makes an appropriate error.
+pub fn test_already_started<T>(mut tracer: T)
+where
+    T: ThreadTracer,
+{
+    tracer.start_tracing().unwrap();
+    match tracer.start_tracing() {
+        Err(HWTracerError::TracerState(TracerState::Started)) => (),
+        _ => panic!(),
+    };
+    tracer.stop_tracing().unwrap();
+}
+
+// Check that stopping an unstarted tracer makes an appropriate error.
+pub fn test_not_started<T>(mut tracer: T)
+where
+    T: ThreadTracer,
+{
+    match tracer.stop_tracing() {
+        Err(HWTracerError::TracerState(TracerState::Stopped)) => (),
+        _ => panic!(),
+    };
+}
+
+// Helper to check an expected list of blocks matches what we actually got.
+pub fn test_expected_blocks(trace: Box<dyn Trace>, mut expect_iter: Iter<Block>) {
+    let mut got_iter = trace.iter_blocks();
+    loop {
+        let expect = expect_iter.next();
+        let got = got_iter.next();
+        if expect.is_none() || got.is_none() {
+            break;
+        }
+        assert_eq!(
+            got.unwrap().unwrap().first_instr(),
+            expect.unwrap().first_instr()
+        );
+    }
+    // Check that both iterators were the same length.
+    assert!(expect_iter.next().is_none());
+    assert!(got_iter.next().is_none());
+}
+
+// Trace two loops, one 10x larger than the other, then check the proportions match the number
+// of block the trace passes through.
+#[cfg(perf_pt_test)]
+pub fn test_ten_times_as_many_blocks<T>(mut tracer1: T, mut tracer2: T)
+where
+    T: ThreadTracer,
+{
+    let trace1 = trace_closure(&mut tracer1, || work_loop(10));
+    let trace2 = trace_closure(&mut tracer2, || work_loop(100));
+
+    // Should be roughly 10x more blocks in trace2. It won't be exactly 10x, due to the stuff
+    // we trace either side of the loop itself. On a smallish trace, that will be significant.
+    let (ct1, ct2) = (trace1.iter_blocks().count(), trace2.iter_blocks().count());
+    assert!(ct2 > ct1 * 9);
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -5,7 +5,7 @@
 
 #![cfg(test)]
 
-use super::{Block, HWTracerError, ThreadTracer, TracerState};
+use super::{Block, HWTracerError, ThreadTracer};
 use crate::Trace;
 use std::slice::Iter;
 use std::time::SystemTime;
@@ -58,7 +58,7 @@ where
 {
     tracer.start_tracing().unwrap();
     match tracer.start_tracing() {
-        Err(HWTracerError::TracerState(TracerState::Started)) => (),
+        Err(HWTracerError::AlreadyTracing) => (),
         _ => panic!(),
     };
     tracer.stop_tracing().unwrap();
@@ -70,7 +70,7 @@ where
     T: ThreadTracer,
 {
     match tracer.stop_tracing() {
-        Err(HWTracerError::TracerState(TracerState::Stopped)) => (),
+        Err(HWTracerError::AlreadyStopped) => (),
         _ => panic!(),
     };
 }


### PR DESCRIPTION
A slightly rag-bag set of commits that aim to make the hwtracer crate a bit easier to work with: separating code out into separate files; and removing what, in retrospect, is unnecessary complexity. This PR manages to delete more code than it adds!

Note I have tested this PR with `yk` and everything still builds and runs fine with these changes.