### PR TITLE
Make the API more thread-safe.

### DIFF
--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -35,15 +35,14 @@ fn work() -> u32 {
 /// The results are printed to discourage the compiler from optimising the computation out.
 fn main() {
     let bldr = TraceCollectorBuilder::new();
-    let col = bldr.build().unwrap();
-    let mut thr_col = unsafe { col.thread_collector() };
+    let tc = bldr.build().unwrap();
 
     for i in 1..4 {
-        thr_col.start_collector().unwrap_or_else(|e| {
+        tc.start_thread_collector().unwrap_or_else(|e| {
             panic!("Failed to start collector: {}", e);
         });
         let res = work();
-        let trace = thr_col.stop_collector().unwrap();
+        let trace = tc.stop_thread_collector().unwrap();
         let name = format!("trace{}", i);
         print_trace(trace, &name, res, 10);
     }

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -86,7 +86,7 @@ impl TraceDecoderBuilder {
 mod test_helpers {
     use super::{TraceDecoder, TraceDecoderBuilder, TraceDecoderKind};
     use crate::{
-        collect::{test_helpers::trace_closure, ThreadTraceCollector},
+        collect::{test_helpers::trace_closure, TraceCollector},
         test_helpers::work_loop,
         Block, Trace,
     };
@@ -121,12 +121,9 @@ mod test_helpers {
 
     /// Trace two loops, one 10x larger than the other, then check the proportions match the number
     /// of block the trace passes through.
-    pub fn ten_times_as_many_blocks(
-        thr_col: &mut dyn ThreadTraceCollector,
-        decoder_kind: TraceDecoderKind,
-    ) {
-        let trace1 = trace_closure(thr_col, || work_loop(10));
-        let trace2 = trace_closure(thr_col, || work_loop(100));
+    pub fn ten_times_as_many_blocks(mut tc: TraceCollector, decoder_kind: TraceDecoderKind) {
+        let trace1 = trace_closure(&mut tc, || work_loop(10));
+        let trace2 = trace_closure(&mut tc, || work_loop(100));
 
         let dec: Box<dyn TraceDecoder> = TraceDecoderBuilder::new()
             .kind(decoder_kind)
@@ -138,6 +135,6 @@ mod test_helpers {
 
         // Should be roughly 10x more blocks in trace2. It won't be exactly 10x, due to the stuff
         // we trace either side of the loop itself. On a smallish trace, that will be significant.
-        assert!(ct2 > ct1 * 9);
+        assert!(ct2 > ct1 * 8);
     }
 }

--- a/tests/pt_chdir_rel.rs
+++ b/tests/pt_chdir_rel.rs
@@ -42,12 +42,10 @@ fn pt_chdir_rel() {
 
     // When we get here, we have a process that was invoked with a relative path.
 
-    let tcol = TraceCollectorBuilder::new().build().unwrap();
-    let mut thr_col = unsafe { tcol.thread_collector() };
-
-    thr_col.start_collector().unwrap();
+    let tc = TraceCollectorBuilder::new().build().unwrap();
+    tc.start_thread_collector().unwrap();
     println!("{}", work_loop(env::args().len() as u64));
-    let trace = thr_col.stop_collector().unwrap();
+    let trace = tc.stop_thread_collector().unwrap();
 
     // Now check that the trace decoder can still find its objects after we change dir.
     let tdec = TraceDecoderBuilder::new().build().unwrap();


### PR DESCRIPTION
Before this change, `ThreadTraceCollector` was exposed to the consumer of the hwtracer API. Calling `TraceCollector::thread_tracer()` would give back a fresh instance each time. This API would allow the user request multiple `ThreadTraceCollector`s on the same thread and start them all "collecting traces" concurrently. This leads to chaos as any given thread can only be traced at most once at a time.

Until now we've swept this under the rug, warning the user not to do the naughty thing unless they want to invoke UB, but the API still allows it to happen.

This change hides `ThreadTraceCollector`s from the public API entirely, leaving `TraceCollector`s to manage thread local instances of `ThreadTraceCollector`.

The user now starts and stops trace collection of a thread with `TraceCollector::start_thread_collector()` and
`TraceCollector::stop_thread_collector()`. `ThreadTraceCollector`s are still there behind the scenes, but the user no longer sees them and thus can't start two tracing the same thread any more.

One subtle side-effect of this new API is that we can no longer automatically stop a running trace collector automatically when the `ThreadTraceCollector` goes out of scope (via `Drop`). Since `ThreadTraceCollector`s are stored (and owned) by thread locals, they never really "fall out of scope", so the user must ensure they consistently stop trace collection before trying to re-trace the same thread.

It may be tempting to stop the current thread's `ThreadTraceCollector` when a `TraceCollector` goes out of scope, but then we'd have to track which `TraceCollector` started the `ThreadTraceCollector` and only stop the collector if they match. This starts to sound pretty over the top, and I think the proposed API is already a lot better than what we had before. Further `TraceCollector::start_thread_collector()` will return a meaningful error message if the user has forgotten to stop a collector, so it shouldn't be hard to track down instances of this blunder.

Fixes #101.